### PR TITLE
fix(release): normalize downloadable asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,13 @@ jobs:
           set -euo pipefail
           mkdir publish-assets
           while IFS= read -r -d '' asset; do
-            cp "$asset" publish-assets/
+            filename="$(basename "$asset")"
+            normalized_name="${filename// /-}"
+            if [ -e "publish-assets/$normalized_name" ]; then
+              echo "Duplicate normalized asset name: $normalized_name" >&2
+              exit 1
+            fi
+            cp "$asset" "publish-assets/$normalized_name"
           done < <(find release-assets -type f \( \
             -name '*.exe' -o \
             -name '*.msi' -o \


### PR DESCRIPTION
## Summary
- replace spaces with hyphens before hashing and uploading release assets
- reject normalized filename collisions
- keep SHA256SUMS filenames identical to downloaded asset names

## Validation
- normalized the five v3.2.1 packages from the real release artifacts
- verified all five checksums with sha256sum --check